### PR TITLE
Fix example.com/Home direct links

### DIFF
--- a/Server/Controllers/HomeController.cs
+++ b/Server/Controllers/HomeController.cs
@@ -33,16 +33,6 @@ namespace AspNetCoreSpa.Server.Controllers
             _applicationDataService = applicationDataService;
         }
 
-        public async Task<IActionResult> Index()
-        {
-            if (ConfirmEmailRequest())
-            {
-                await ConfirmEmail();
-            }
-
-            return View();
-        }
-
         [HttpPost]
         public IActionResult SetLanguage(string culture)
         {


### PR DESCRIPTION
Fixes the following error when accessing example.com/Home directly (not via angular route):
```
InvalidOperationException: The view 'Index' was not found. The following locations were searched:
/Views/Home/Index.en-US.cshtml
/Views/Home/Index.en.cshtml
/Views/Home/Index.cshtml
/Views/Shared/Index.en-US.cshtml
/Views/Shared/Index.en.cshtml
/Views/Shared/Index.cshtml
```
The angular route handling won't work because as you can see MVC / Asp.Net Core routing tries to handle it.

The view does not exist anymore anyway, so there is no need to keep that method. ConfirmEmail would throw this error too (not sure if email is still confirmed from here).
