### PR TITLE
Fix for immutable HttpParams in build url search params

### DIFF
--- a/ClientApp/src/app/core/services/data.service.ts
+++ b/ClientApp/src/app/core/services/data.service.ts
@@ -62,7 +62,7 @@ export class DataService {
         let searchParams = new HttpParams();
         for (const key in params) {
             if (params.hasOwnProperty(key)) {
-                searchParams.append(key, params[key]);
+                searchParams= searchParams.append(key, params[key]);
             }
         }
         return searchParams;


### PR DESCRIPTION
Hi Asad

I've added a small fix for buildUrlSearchParams.

Currently HttpParams is immutable so you should set params as below:
// for set method
let params: HttpParams = new HttpParams().set('something', 'hello');
// for append method
let params: HttpParams = new HttpParams().append('something', 'hello');

Here is the topic on stackoverflow 
https://stackoverflow.com/questions/45500264/angular-4-3-httpclient-get-params-empty


Best regards,
Krzysztof 