### PR TITLE
translations through csv

### DIFF
--- a/src/AspNetCoreSpa.Core/Extensions/EnumExtensions.cs
+++ b/src/AspNetCoreSpa.Core/Extensions/EnumExtensions.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace AspNetCoreSpa.Web.Extensions
+namespace AspNetCoreSpa.Core
 {
     public static class EnumExtensions
     {

--- a/src/AspNetCoreSpa.Core/Extensions/HostingEnvironmentExtensions.cs
+++ b/src/AspNetCoreSpa.Core/Extensions/HostingEnvironmentExtensions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System.IO;
+
+namespace AspNetCoreSpa.Core
+{
+    public static class HostingEnvironmentExtensions
+    {
+        public static string[] GetTranslationFile(this IHostingEnvironment hostingEnvironment)
+        {
+            return File.ReadAllLines(Path.Combine(hostingEnvironment.ContentRootPath, "translations.csv"));
+        }
+
+    }
+}

--- a/src/AspNetCoreSpa.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/AspNetCoreSpa.Web/Extensions/ServiceCollectionExtensions.cs
@@ -16,6 +16,9 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using AspNetCoreSpa.Core.Entities;
 using AspNetCoreSpa.Infrastructure;
+using System.IO;
+using System.Linq;
+using AspNetCoreSpa.Core;
 
 namespace AspNetCoreSpa.Web.Extensions
 {
@@ -214,22 +217,22 @@ namespace AspNetCoreSpa.Web.Extensions
             return services;
         }
 
-        public static IServiceCollection AddCustomLocalization(this IServiceCollection services)
+        public static IServiceCollection AddCustomLocalization(this IServiceCollection services, IHostingEnvironment hostingEnvironment)
         {
-            services.Configure<RequestLocalizationOptions>(opts =>
-                {
-                    var supportedCultures = new List<CultureInfo>
-                    {
-                                new CultureInfo("en-US"),
-                                new CultureInfo("fr-FR")
-                    };
+            var translationFile = hostingEnvironment.GetTranslationFile();
 
-                    opts.DefaultRequestCulture = new RequestCulture("en-US");
-                    // Formatting numbers, dates, etc.
-                    opts.SupportedCultures = supportedCultures;
-                    // UI strings that we have localized.
-                    opts.SupportedUICultures = supportedCultures;
-                });
+            var cultures = translationFile.First().Split(",").Skip(1);
+
+            services.Configure<RequestLocalizationOptions>(opts =>
+            {
+                var supportedCultures = cultures.Select(c => new CultureInfo(c)).ToList();
+
+                opts.DefaultRequestCulture = new RequestCulture(cultures.First());
+                // Formatting numbers, dates, etc.
+                opts.SupportedCultures = supportedCultures;
+                // UI strings that we have localized.
+                opts.SupportedUICultures = supportedCultures;
+            });
 
             services.AddLocalization(options => options.ResourcesPath = "Resources");
 

--- a/src/AspNetCoreSpa.Web/Startup.cs
+++ b/src/AspNetCoreSpa.Web/Startup.cs
@@ -59,7 +59,7 @@ namespace AspNetCoreSpa.Web
             services.AddSignalR()
                 .AddMessagePackProtocol();
 
-            services.AddCustomLocalization();
+            services.AddCustomLocalization(HostingEnvironment);
 
             services.AddCustomizedMvc();
 

--- a/src/AspNetCoreSpa.Web/translations.csv
+++ b/src/AspNetCoreSpa.Web/translations.csv
@@ -1,0 +1,19 @@
+ContentKey,en-US,fr-FR
+app_title,AspNetCoreSpa,fr-AspNetCoreSpa
+app_description,Single page application using aspnet core and angular,fr-Single page application using aspnet core and angular
+app_repo_url,https://github.com/asadsahi/aspnetcorespa,https://github.com/asadsahi/aspnetcorespa
+app_nav_home,Home,fr-Home
+app_nav_signalr,SignalR,fr-SignalR
+app_nav_examples,Examples,fr-Examples
+app_nav_register,Register,fr-Register
+app_nav_login,Login,fr-Login
+app_nav_logout,Logout,fr-Logout
+app_login_btn,Login,fr-Login
+app_registry_btn,Register,fr-Register
+app_email,Email,fr-Email
+app_password,Password,fr-Password
+app_username,Username,fr-Username
+app_firstname,Firstname,fr-Firstname
+app_lastname,Lastname,fr-Lastname
+app_mobile,Mobile,fr-Mobile
+app_forget_password,Forget password? click here,fr-Forget password? click here


### PR DESCRIPTION
@SanyaBogos have a look at this PR, this one is simpler but achieving the same goal of managing translations through csv file. ClientSide still needs to wire up with translations, but can be done at some point.

Key things to note is that we dont' need to rely on any external csv parser package. simple file reading is enough. no hardcoded string of cultures. All managed through file. Right now there are only two cultures but can easily be extended for any more cultures.

Let me know what do you think or if anything is missing before I merge into master.

Thanks